### PR TITLE
Feature/maven failsafe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ target/
 # Ignore IntelliJ files
 .idea/
 download-directory.iml
+
+# Ignore integration test files
+protege_files.tar
+protege_files/
+src/main/resources/run_protege_exporter.log

--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,26 @@
 				</executions>
 			</plugin>
 
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>2.19.1</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.19.1</version>
+			</plugin>
+
 			<!--
 			allows 'mvn release' command to create a new release of the project
 			https://maven.apache.org/maven-release/maven-release-plugin/

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,11 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<!--
+		integration tests run by default when running the command "mvn verify"; can be overridden using the option
+		"-DskipITs=true"
+		-->
+		<skipITs>false</skipITs>
 
 		<spring.version>4.2.4.RELEASE</spring.version>
 		<biopax.version>5.1.0</biopax.version>
@@ -74,7 +79,7 @@
 			<artifactId>log4j-core</artifactId>
 			<version>2.11.0</version>
 		</dependency>
-		<!-- release-common-lib must be before biopax dependencies to avoid conflict between libraries -->
+		<!-- release-common-lib must be before BioPAX dependencies to avoid conflict between libraries -->
 		<dependency>
 			<groupId>org.reactome.release</groupId>
 			<artifactId>release-common-lib</artifactId>
@@ -213,21 +218,24 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>2.19.1</version>
+				<version>2.22.2</version>
 				<executions>
 					<execution>
+						<id>integration-tests</id>
 						<goals>
 							<goal>integration-test</goal>
 							<goal>verify</goal>
 						</goals>
+						<configuration>
+							<!--
+							Default value is defined in the <properties> section and will be applied to integration
+							tests when running the command "mvn verify", but can be overwritten to either skip
+							or run integration tests with the command "mvn verify -DskipITs=[true|false]"
+							-->
+							<skipTests>${skipITs}</skipTests>
+						</configuration>
 					</execution>
 				</executions>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.19.1</version>
 			</plugin>
 
 			<!--

--- a/src/main/java/org/reactome/release/downloaddirectory/ProtegeExporter.java
+++ b/src/main/java/org/reactome/release/downloaddirectory/ProtegeExporter.java
@@ -168,6 +168,9 @@ public class ProtegeExporter
 								{
 									Files.createDirectories(Paths.get(PROTEGE_FILES_DIR));
 									// Move the file to the protege_files, overwrite existing.
+									Files.delete(Paths.get("/tmp", fileName + ".pins"));
+									Files.delete(Paths.get("/tmp", fileName + ".pont"));
+									Files.delete(Paths.get("/tmp", fileName + ".pprj"));
 									Files.move(Paths.get("/tmp/"+fileName+".tar.gz"), Paths.get(PROTEGE_FILES_DIR+fileName+".tar.gz"), StandardCopyOption.REPLACE_EXISTING);
 								}
 								else

--- a/src/main/java/org/reactome/release/downloaddirectory/ProtegeExporter.java
+++ b/src/main/java/org/reactome/release/downloaddirectory/ProtegeExporter.java
@@ -123,8 +123,8 @@ public class ProtegeExporter
 				// know they could still be running.
 				Runtime.getRuntime().addShutdownHook(new Thread( () ->
 				{
-					logger.info("Shutting down thread pool. IF this program was terminated prematurely, there might still be orphan Perl processe runing."
-								+ " Check to see if any are still running, and kill them if necssary.");
+					logger.info("Shutting down thread pool. IF this program was terminated prematurely, there might still be orphan Perl processes running."
+								+ " Check to see if any are still running, and kill them if necessary.");
 					pool.shutdownNow();
 				}));
 				// Filtering is in effect IF the set has something in it.
@@ -153,7 +153,7 @@ public class ProtegeExporter
 							// include a normalized display_name in the output to make it easier to identify the contents of an archive.
 							String normalizedDisplayName = pathway.getDisplayName().toLowerCase().replace(" ", "_").replace("-", "_").replace("(", "").replace(")", "");
 							String fileName = "Reactome_pathway_" + pathway.getDBID() + "_" + normalizedDisplayName;
-							ProcessBuilder processBuilder = createProcessBuilder(pathway.getDBID().toString(), fileName);
+							ProcessBuilder processBuilder = createProcessBuilder(pathway.getDBID().toString(), fileName, dba);
 							Process process = null;
 							try
 							{
@@ -165,7 +165,7 @@ public class ProtegeExporter
 								logger.info("Finished generating protege files for {}; Elapsed time: {}; Exit code is {}", pathway.toString(), Duration.between(exportStart, exportEnd), exitCode);
 								if (exitCode == 0)
 								{
-									Files.createDirectories(Paths.get("/tmp/protege_files"));
+									Files.createDirectories(Paths.get(PROTEGE_FILES_DIR));
 									// Move the file to the protege_files, overwrite existing.
 									Files.move(Paths.get("/tmp/"+fileName+".tar.gz"), Paths.get(PROTEGE_FILES_DIR+fileName+".tar.gz"), StandardCopyOption.REPLACE_EXISTING);
 								}
@@ -206,7 +206,7 @@ public class ProtegeExporter
 	 * Determine if a pathway should be processed. A pathway should be processed IF: <ul>
 	 * <li>An ID filter has been specified and the pathway's ID is in that set.</li>
 	 * <li>A species filter has been specified and the pathway's species is in that set.</li></ul>
-	 * If an ID filter has NOT been specified, then no filtering by ID will occurr. If a species filter has NOT be specified, then no filtering by species will occur.
+	 * If an ID filter has NOT been specified, then no filtering by ID will occur. If a species filter has NOT be specified, then no filtering by species will occur.
 	 * If NO filters are specified, then this function will return true for any pathway.
 	 * @param idFilterInEffect
 	 * @param speciesFilterInEffect
@@ -247,14 +247,22 @@ public class ProtegeExporter
 	 * Create a process builder to run the protege export process.
 	 * @param pathwayId - the DB_ID of the Pathway to export.
 	 * @param fileName - This string will be used to name the output archive file that is created by protege export.
+	 * @param dba - the database from which the pathway originates
 	 * @return A populated ProcessBuilder that is ready to use.
 	 */
-	private ProcessBuilder createProcessBuilder(String pathwayId, String fileName)
+	private ProcessBuilder createProcessBuilder(String pathwayId, String fileName, MySQLAdaptor dba)
 	{
 		List<String> cmdArgs = new ArrayList<>();
 		cmdArgs.add("perl");
 		cmdArgs.addAll(this.extraIncludes);
-		cmdArgs.addAll(Arrays.asList("-I"+this.releaseDirectory+"/modules", "run_protege_exporter.pl", pathwayId, fileName));
+		cmdArgs.addAll(Arrays.asList("-I"+this.releaseDirectory+"/modules", "run_protege_exporter.pl",
+			"id=" + pathwayId,
+			"file_name=" + fileName,
+			"DB=" + dba.getDBName(),
+			"db_user=" + dba.getDBUser(),
+			"db_pass=" + dba.getDBPwd(),
+			"db_host=" + dba.getDBHost()
+		));
 		// Build the process.
 		ProcessBuilder processBuilder = new ProcessBuilder();
 		processBuilder.command(cmdArgs)
@@ -266,7 +274,6 @@ public class ProtegeExporter
 
 	/**
 	 * TARs the protege files.
-	 * @param pathToProtegeFiles The path to where the protege archive files are. They need to be collected into a single archive.
 	 */
 	private void tarProtegeFiles()
 	{

--- a/src/main/java/org/reactome/release/downloaddirectory/ProtegeExporter.java
+++ b/src/main/java/org/reactome/release/downloaddirectory/ProtegeExporter.java
@@ -124,8 +124,10 @@ public class ProtegeExporter
 				// know they could still be running.
 				Runtime.getRuntime().addShutdownHook(new Thread( () ->
 				{
-					logger.info("Shutting down thread pool. IF this program was terminated prematurely, there might still be orphan Perl processes running."
-								+ " Check to see if any are still running, and kill them if necessary.");
+					logger.info("Shutting down thread pool.");
+					logger.warn("IF this program was terminated prematurely, there might still be orphan Perl " +
+						"processes running. Check to see if any are still running, and kill them if necessary."
+					);
 					pool.shutdownNow();
 				}));
 				// Filtering is in effect IF the set has something in it.

--- a/src/main/java/org/reactome/release/downloaddirectory/ProtegeExporter.java
+++ b/src/main/java/org/reactome/release/downloaddirectory/ProtegeExporter.java
@@ -272,7 +272,9 @@ public class ProtegeExporter
 		processBuilder.command(cmdArgs)
 					.directory(Paths.get(this.pathToWrapperScript).toFile())
 					.inheritIO();
-		logger.info("Command is: `{}`", String.join(" ", processBuilder.command()));
+		logger.info("Command is: `{}`",
+			String.join(" ", processBuilder.command()).replace("db_pass=" + dba.getDBPwd(), "db_pass=********")
+		);
 		return processBuilder;
 	}
 

--- a/src/main/java/org/reactome/release/downloaddirectory/ProtegeExporter.java
+++ b/src/main/java/org/reactome/release/downloaddirectory/ProtegeExporter.java
@@ -42,7 +42,8 @@ public class ProtegeExporter
 	// The code in GKB::WebUtils always writes protege files to /tmp/ and it doesn't look like that is configurable,
 	// so we'll work in /tmp as well.
 	private static final String PROTEGE_ARCHIVE_PATH = "/tmp/protege_files.tar";
-	private static final String PROTEGE_FILES_DIR = PROTEGE_ARCHIVE_PATH.replace(".tar", "/");
+	static final String PROTEGE_FILES_DIR = PROTEGE_ARCHIVE_PATH.replace(".tar", "/");
+
 	private static final Logger logger = LogManager.getLogger();
 	private String releaseDirectory;
 	private int parallelism = ForkJoinPool.getCommonPoolParallelism();

--- a/src/main/resources/run_protege_exporter.pl
+++ b/src/main/resources/run_protege_exporter.pl
@@ -1,11 +1,28 @@
 #!/usr/bin/perl
-
-use GKB::WebUtils;
 use strict;
 use warnings;
 
-my $wu = GKB::WebUtils->new_from_cgi();
-my $id = $ARGV[0] || die "No ID specified specified.\n";
-my $file_name = $ARGV[1] || die "No filename specified specified.\n";
+use CGI;
+
+use GKB::DBAdaptor;
+use GKB::WebUtils;
+
+my $cgi = CGI->new();
+
+my $user = $cgi->param("db_user");
+my $pass = $cgi->param("db_pass");
+my $host = $cgi->param("db_host");
+my $db = $cgi->param("DB");
+
+my $dba = GKB::DBAdaptor->new(
+    -user   => $user,
+    -pass   => $pass,
+    -host   => $host,
+    -dbName => $db
+);
+
+my $wu = GKB::WebUtils->new(-cgi => $cgi, -dba => $dba);
+my $id = $cgi->param("id") || die "No ID specified specified.\n";
+my $file_name = $cgi->param("file_name") || die "No filename specified specified.\n";
 
 $wu->create_protege_project_wo_orthologues($file_name,[$id]);

--- a/src/test/java/org/reactome/release/downloaddirectory/ProtegeExporterIT.java
+++ b/src/test/java/org/reactome/release/downloaddirectory/ProtegeExporterIT.java
@@ -3,19 +3,22 @@ package org.reactome.release.downloaddirectory;
 import static org.junit.Assert.assertTrue;
 
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
+import java.util.stream.Collectors;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.io.FileUtils;
 import org.gk.persistence.MySQLAdaptor;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,61 +27,61 @@ import org.junit.Test;
 public class ProtegeExporterIT
 {
 	private static final String RELEASE_NUM = "70";
+	private static final String pathToJavaRoot = ".";
+
 	private static String host;
 	private static String name;
 	private static String user;
 	private static String password;
-	// Set pathToJavaRoot from the command line as: -DpathToJavaRoot="/path/to/data-release-pipeline/downloadDirectory/"
-	static final String pathToJavaRoot = System.getProperty("pathToJavaRoot");
-	// Set clean up from the command line as: -Dcleanup=true
-	static final boolean cleanupAfterTest = Boolean.valueOf(System.getProperty("cleanup"));
+	private static String releaseDir;
+	private static List<String> perlLibPaths;
 
 	@Before
-	public void setup() throws FileNotFoundException, IOException, Exception
+	public void setup() throws IOException
 	{
-		if (pathToJavaRoot == null || pathToJavaRoot.trim().isEmpty())
-		{
-			throw new Exception("pathToJavaRoot cannot be empty! Set the value when running Java as: -DpathToJavaRoot=\"/path/to/data-release-pipeline/downloadDirectory/\"");
-		}
-
 		System.out.println("pathToJavaRoot is: " + pathToJavaRoot);
 
 		Properties props = new Properties();
-		try(FileInputStream fis = new FileInputStream("src/test/resources/db.properties"))
-		{
-			props.load(fis);
-			ProtegeExporterIT.host = props.getProperty("db.host");
-			ProtegeExporterIT.name = props.getProperty("db.name");
-			ProtegeExporterIT.user = props.getProperty("db.user");
-			ProtegeExporterIT.password = props.getProperty("db.password");
-			String release = RELEASE_NUM;
-			Files.createDirectories(Paths.get(release+"/"));
+		try(FileInputStream integrationTestProperties = new FileInputStream("src/test/resources/it.properties")) {
+			props.load(integrationTestProperties);
 		}
+
+		ProtegeExporterIT.host = props.getProperty("db.host");
+		ProtegeExporterIT.name = props.getProperty("db.name");
+		ProtegeExporterIT.user = props.getProperty("db.user");
+		ProtegeExporterIT.password = props.getProperty("db.password");
+		ProtegeExporterIT.releaseDir = props.getProperty("release.dir");
+		ProtegeExporterIT.perlLibPaths = getPerlLibPathArguments(props.getProperty("perllib.paths"));
+
+		Files.createDirectories(Paths.get(RELEASE_NUM));
 	}
 
 	@Test
 	public void testProtegeExporterIT() throws SQLException, IOException
 	{
-		MySQLAdaptor adaptor = new MySQLAdaptor(ProtegeExporterIT.host, ProtegeExporterIT.name, ProtegeExporterIT.user, ProtegeExporterIT.password);
+		MySQLAdaptor adaptor = new MySQLAdaptor(
+			ProtegeExporterIT.host, ProtegeExporterIT.name, ProtegeExporterIT.user, ProtegeExporterIT.password
+		);
 
 		ProtegeExporter testExporter = new ProtegeExporter();
 
-		testExporter.setReleaseDirectory("/home/sshorser/workspaces/reactome/Release");
-		testExporter.setPathToWrapperScript(pathToJavaRoot + "src/main/resources/");
-		testExporter.setExtraIncludes(Arrays.asList("-I/home/ubuntu/perl5/lib/perl5/","-I/home/sshorser/perl5/lib/perl5/"));
+		testExporter.setReleaseDirectory(releaseDir);
+		testExporter.setPathToWrapperScript(Paths.get(pathToJavaRoot, "src", "main", "resources").toString());
+		testExporter.setExtraIncludes(perlLibPaths);
 		testExporter.setParallelism(4);
-		Set<Long> pathwayIds = new HashSet<>(Arrays.asList(1670466L,8963743L,870392L,1500931L,5205647L));
+		Set<Long> pathwayIds = new HashSet<>(Arrays.asList(1670466L, 8963743L, 870392L, 1500931L, 5205647L));
 		testExporter.setPathwayIdsToProcess(pathwayIds);
 		testExporter.setDownloadDirectory(RELEASE_NUM);
-		testExporter.setSpeciesToProcess(new HashSet<>(Arrays.asList("Mycobacterium tuberculosis")));
+		testExporter.setSpeciesToProcess(new HashSet<>(Collections.singletonList("Mycobacterium tuberculosis")));
 		testExporter.execute(adaptor);
-		final String pathToFinalTar = pathToJavaRoot + RELEASE_NUM + "/protege_files.tar";
+
+		final String pathToFinalTar = Paths.get(pathToJavaRoot, RELEASE_NUM, "protege_files.tar").toString();
 		assertTrue(Files.exists(Paths.get(pathToFinalTar)));
 		assertTrue(Files.size(Paths.get(pathToFinalTar)) > 0);
 
 		// Now, let's see if the tar contents are valid.
 		try(InputStream inStream = new FileInputStream(pathToFinalTar);
-			TarArchiveInputStream tains = new TarArchiveInputStream(inStream);)
+			TarArchiveInputStream tains = new TarArchiveInputStream(inStream))
 		{
 			boolean done = false;
 			boolean tarContainsPathwayID = false;
@@ -104,11 +107,28 @@ public class ProtegeExporterIT
 			}
 			assertTrue(tarContainsPathwayID);
 		}
-		if (cleanupAfterTest)
+
+		if (cleanupAfterTest())
 		{
 			System.out.println("You specified \"cleanup\", so " + pathToFinalTar + " will now be removed.");
-			Files.delete(Paths.get(pathToFinalTar));
+			FileUtils.deleteDirectory(Paths.get(RELEASE_NUM).toFile());
 		}
 	}
 
+	// Set clean up from the command line as: -Dcleanup=true (cleanup is false by default)
+	private boolean cleanupAfterTest()
+	{
+		String cleanupAfterTest = System.getProperty("cleanup");
+
+		return cleanupAfterTest != null && Boolean.parseBoolean(cleanupAfterTest);
+	}
+
+	// Takes a comma delimited String of paths to library directories for Perl, appends the "-I" flag, and returns
+	// the paths as a list of Strings
+	private List<String> getPerlLibPathArguments(String perlLibPaths)
+	{
+		return Arrays.stream(perlLibPaths.split(","))
+			.map(path -> "-I" + path)
+			.collect(Collectors.toList());
+	}
 }

--- a/src/test/java/org/reactome/release/downloaddirectory/ProtegeExporterIT.java
+++ b/src/test/java/org/reactome/release/downloaddirectory/ProtegeExporterIT.java
@@ -53,6 +53,14 @@ public class ProtegeExporterIT
 		ProtegeExporterIT.releaseDir = props.getProperty("release.dir");
 		ProtegeExporterIT.perlLibPaths = getPerlLibPathArguments(props.getProperty("perllib.paths"));
 
+		if (releaseDir == null || releaseDir.isEmpty())
+		{
+			throw new RuntimeException(
+				"release.dir must have a value, for the path of the Release directory " +
+				"(https://github.com/reactome/Release/), set in src/test/resources/it.properties"
+			);
+		}
+
 		Files.createDirectories(Paths.get(RELEASE_NUM));
 	}
 

--- a/src/test/java/org/reactome/release/downloaddirectory/ProtegeExporterIT.java
+++ b/src/test/java/org/reactome/release/downloaddirectory/ProtegeExporterIT.java
@@ -21,7 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 @SuppressWarnings("static-method")
-public class TestProtegeExporter
+public class ProtegeExporterIT
 {
 	private static final String RELEASE_NUM = "70";
 	private static String host;
@@ -47,10 +47,10 @@ public class TestProtegeExporter
 		try(FileInputStream fis = new FileInputStream("src/test/resources/db.properties"))
 		{
 			props.load(fis);
-			TestProtegeExporter.host = props.getProperty("db.host");
-			TestProtegeExporter.name = props.getProperty("db.name");
-			TestProtegeExporter.user = props.getProperty("db.user");
-			TestProtegeExporter.password = props.getProperty("db.password");
+			ProtegeExporterIT.host = props.getProperty("db.host");
+			ProtegeExporterIT.name = props.getProperty("db.name");
+			ProtegeExporterIT.user = props.getProperty("db.user");
+			ProtegeExporterIT.password = props.getProperty("db.password");
 			String release = RELEASE_NUM;
 			Files.createDirectories(Paths.get(release+"/"));
 		}
@@ -59,7 +59,7 @@ public class TestProtegeExporter
 	@Test
 	public void testProtegeExporterIT() throws SQLException, IOException
 	{
-		MySQLAdaptor adaptor = new MySQLAdaptor(TestProtegeExporter.host, TestProtegeExporter.name, TestProtegeExporter.user, TestProtegeExporter.password);
+		MySQLAdaptor adaptor = new MySQLAdaptor(ProtegeExporterIT.host, ProtegeExporterIT.name, ProtegeExporterIT.user, ProtegeExporterIT.password);
 
 		ProtegeExporter testExporter = new ProtegeExporter();
 

--- a/src/test/java/org/reactome/release/downloaddirectory/ProtegeExporterIT.java
+++ b/src/test/java/org/reactome/release/downloaddirectory/ProtegeExporterIT.java
@@ -110,8 +110,12 @@ public class ProtegeExporterIT
 
 		if (cleanupAfterTest())
 		{
-			System.out.println("You specified \"cleanup\", so " + pathToFinalTar + " will now be removed.");
+			System.out.println(
+				"You specified \"cleanup\", so the directories \"" + RELEASE_NUM + "\" and \"" +
+				ProtegeExporter.PROTEGE_FILES_DIR + "\" will now be removed."
+			);
 			FileUtils.deleteDirectory(Paths.get(RELEASE_NUM).toFile());
+			FileUtils.deleteDirectory(Paths.get(ProtegeExporter.PROTEGE_FILES_DIR).toFile());
 		}
 	}
 

--- a/src/test/resources/db.properties
+++ b/src/test/resources/db.properties
@@ -1,5 +1,0 @@
-db.user=root
-db.password=root
-db.host=localhost
-db.port=3306
-db.name=release_current_before_addlinks_69

--- a/src/test/resources/it.properties
+++ b/src/test/resources/it.properties
@@ -2,7 +2,7 @@ db.user=root
 db.password=root
 db.host=localhost
 db.port=3306
-db.name=bm
+db.name=test_reactome_70
 
 release.dir=/home/jweiser/GitHub/Release
 perllib.paths=/home/jweiser/perl5/lib/perl5/,/home/jweiser/perl5/lib/perl5/

--- a/src/test/resources/it.properties
+++ b/src/test/resources/it.properties
@@ -1,0 +1,8 @@
+db.user=root
+db.password=root
+db.host=localhost
+db.port=3306
+db.name=bm
+
+release.dir=/home/jweiser/GitHub/Release
+perllib.paths=/home/jweiser/perl5/lib/perl5/,/home/jweiser/perl5/lib/perl5/


### PR DESCRIPTION
This PR:

- adds the maven-failsafe plugin to allow 'mvn verify' to detect protege exporter integration testing and be run separately from the unit testing in the 'mvn test' phase
- updates the protege exporter integration testing code
