### PR TITLE
Restrict Old Stable Identifier mapping to current IDs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,9 +30,7 @@ pipeline {
 		stage('Setup: Install Pathway Exchange artifact'){
 			steps{
 				script{
-					dir('download-directory'){
-						sh "./build_pathway_exchange.sh"
-					}
+					sh "./build_pathway_exchange.sh"
 				}
 			}
 		}
@@ -41,11 +39,9 @@ pipeline {
 		stage('Setup: Build DownloadDirectory archive'){
 			steps{
 				script{
-					dir('download-directory'){
-						sh "mvn clean package -DskipTests"
-						sh "rm -rf download-directory"
-						sh "unzip -o target/download-directory-distr.zip"
-					}
+					sh "mvn clean package -DskipTests"
+					sh "rm -rf download-directory"
+					sh "unzip -o target/download-directory-distr.zip"
 				}
 			}
 		}
@@ -54,11 +50,9 @@ pipeline {
 		stage('Main: Run DownloadDirectory'){
 			steps{
 				script{
-					dir('download-directory'){
-						withCredentials([file(credentialsId: 'Config', variable: 'ConfigFile')]){
-							withCredentials([file(credentialsId: 'stepsToRun', variable: 'StepsToRun')]){
-								sh "java -Xmx${env.JAVA_MEM_MAX}m -javaagent:download-directory/lib/spring-instrument-4.2.4.RELEASE.jar -jar download-directory/download-directory.jar $ConfigFile $StepsToRun"
-							}
+					withCredentials([file(credentialsId: 'Config', variable: 'ConfigFile')]){
+						withCredentials([file(credentialsId: 'stepsToRun', variable: 'StepsToRun')]){
+							sh "java -Xmx${env.JAVA_MEM_MAX}m -javaagent:download-directory/lib/spring-instrument-4.2.4.RELEASE.jar -jar download-directory/download-directory.jar $ConfigFile $StepsToRun"
 						}
 					}
 				}
@@ -68,12 +62,10 @@ pipeline {
 		stage('Post: Archive logs and validation files'){
 			steps{
 				script{
-					dir('download-directory'){
-						sh "mkdir -p archive/${currentRelease}/logs"
-						sh "mv --backup=numbered biopax*validator.zip archive/${currentRelease}/"
-						sh "gzip logs/*"
-						sh "mv logs/* archive/${currentRelease}/logs/"
-					}
+					sh "mkdir -p archive/${currentRelease}/logs"
+					sh "mv --backup=numbered biopax*validator.zip archive/${currentRelease}/"
+					sh "gzip logs/*"
+					sh "mv logs/* archive/${currentRelease}/logs/"
 				}
 			}
 		}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,6 @@ pipeline {
 
 	stages {
 		// This stage checks that an upstream project, AddLinks-Insertion, was run successfully for its last build.
-		/*
 		stage('Check AddLinks-Insertion build succeeded'){
 			steps{
 				script{
@@ -27,7 +26,6 @@ pipeline {
 				}
 			}
 		}
-		*/
 		// This stage clones, builds, and install the Pathway-Exchange dependency needed for DownloadDirectory.
 		stage('Setup: Install Pathway Exchange artifact'){
 			steps{

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ pipeline {
 
 	stages {
 		// This stage checks that an upstream project, AddLinks-Insertion, was run successfully for its last build.
+		/*
 		stage('Check AddLinks-Insertion build succeeded'){
 			steps{
 				script{
@@ -26,6 +27,7 @@ pipeline {
 				}
 			}
 		}
+		*/
 		// This stage clones, builds, and install the Pathway-Exchange dependency needed for DownloadDirectory.
 		stage('Setup: Install Pathway Exchange artifact'){
 			steps{

--- a/src/main/java/org/reactome/release/downloaddirectory/Main.java
+++ b/src/main/java/org/reactome/release/downloaddirectory/Main.java
@@ -130,7 +130,7 @@ public class Main {
 			// This step iterates through all StableIdentifiers and maps them to the old Reactome ID in 'REACT_#####' format. Human instances are displayed first.
 			// Output: reactome_stable_ids.txt
 			try {
-				MapOldStableIds.execute(username, password, host, releaseNumber);
+				MapOldStableIds.execute(dbAdaptor, releaseNumber);
 			} catch (Exception e) {
 				failedSteps.add("MapOldStableIds");
 				e.printStackTrace();

--- a/src/main/java/org/reactome/release/downloaddirectory/MapOldStableIds.java
+++ b/src/main/java/org/reactome/release/downloaddirectory/MapOldStableIds.java
@@ -2,40 +2,44 @@ package org.reactome.release.downloaddirectory;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.gk.model.GKInstance;
+import org.gk.model.ReactomeJavaConstants;
+import org.gk.persistence.MySQLAdaptor;
 
-import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.sql.*;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class MapOldStableIds {
 	private static final Logger logger = LogManager.getLogger();
 	private static final String filename = "reactome_stable_ids.txt";
 
-	public static void execute(String username, String password, String host, String releaseNumber) throws Exception {
+	/**
+	 * This DownloadDirectory module produces a mapping file of current Reactome stable identifiers to old Reactome stable identifiers.
+	 * This stable identifiers denote specific instances in Reactome (Pathway, Reaction, Protein) and can be used to access their pages externally.
+	 * After release '53', Reactome switched its stable identifier format from 'REACT_XXXXX' to 'R-ABC-XXXXXX'. This new format
+	 * contained a bit more information ('ABC' denotes the species) while also mitigating a database corruption issue that sometimes caused
+	 * multiple stable identifiers to be mapped to a single instance.
+	 * @param dba MySQLAdaptor - Connects to release_current relational database.
+	 * @param releaseNumber String - Current release number, used for storing files in release-specific location.
+	 * @throws Exception - Can be an IOException (Moving/Writing issues), SQLException (Connecting/Querying/Interacting with stable_identifiers database),
+	 * ClassNotFoundException (if MySQL driver class isn't found) or a general Exception thrown from the MySQLAdaptor class.
+	 */
+	public static void execute(MySQLAdaptor dba, String releaseNumber) throws Exception {
 
 		logger.info("Running MapOldStableIds step");
-		// Need to use mysql driver to access stable_identifiers db
-		logger.info("Connecting to stable_identifers db...");
-		Class.forName("com.mysql.jdbc.Driver");
-		Connection connect = DriverManager.getConnection("jdbc:mysql://" + host + "/stable_identifiers?" + "user=" + username + "&password=" + password);
-		Statement statement = connect.createStatement();
-		ResultSet resultSet = statement.executeQuery("SELECT identifier,instanceId FROM StableIdentifier");
-
+		ResultSet stableIdResults = retrieveAllStableIdentifiers(dba);
 
 		logger.info("Mapping Old Stable IDs to Current Stable IDs...");
-		Map<String, List<String>> dbIdToStableIds = getDbIdToStableIds(resultSet);
+		Map<String, List<String>> dbIdToStableIds = getDbIdToStableIds(stableIdResults);
 		List<String> dbIds = new ArrayList<>(dbIdToStableIds.keySet());
 		Collections.sort(dbIds);
 
-		// Iterate through array of stable IDs associated with DB ID, splitting into human and non-human groups
+		// Iterate through array of stable IDs associated with DB ID, splitting into human and non-human groups.
 		List<List<Object>> hsaIds = new ArrayList<>();
 		List<List<Object>> nonHsaIds = new ArrayList<>();
 		for (String dbId : dbIds)
@@ -65,11 +69,11 @@ public class MapOldStableIds {
 			}
 		}
 
-		// Reorder the data so that the interior arrays that have only 1 element are going to be output first
+		// Reorder the data so that the interior arrays that have only 1 element are going to be output first.
 		List<List<Object>> combinedIds = new ArrayList<>();
 		combinedIds.addAll(hsaIds);
 		combinedIds.addAll(nonHsaIds);
-		List<List<Object>> preferredIds = new ArrayList<>();
+		List<List<Object>> stableIdsToOldIdsMappings = new ArrayList<>();
 		List<List<Object>> deferredIds = new ArrayList<>();
 		for (List<Object> stableIdsArray : combinedIds)
 		{
@@ -79,50 +83,107 @@ public class MapOldStableIds {
 			{
 				deferredIds.add(stableIdsArray);
 			} else {
-				preferredIds.add(stableIdsArray);
+				stableIdsToOldIdsMappings.add(stableIdsArray);
 			}
 		}
-		preferredIds.addAll(deferredIds);
+		stableIdsToOldIdsMappings.addAll(deferredIds);
+
+		logger.info("Retrieving current stable identifiers from " + dba.getDBName());
+		Set<String> currentStableIdentifiers = getCurrentStableIdentifiers(dba);
 
 		// Write to file
-		File oldIdMappingFile = new File(filename);
-		if (oldIdMappingFile.exists()) {
-			oldIdMappingFile.delete();
-		}
-		oldIdMappingFile.createNewFile();
-		String header = "# Reactome stable IDs for release " + releaseNumber + "\n" + "Stable_ID\told_identifier(s)\n";
-		Files.write(Paths.get(filename), header.getBytes(), StandardOpenOption.APPEND);
-		for (List<Object> stableIdsArray : preferredIds)
-		{
-			String primaryId = (String) stableIdsArray.get(0);
-			@SuppressWarnings("unchecked")
-			List<String> secondaryIds = (ArrayList<String>) stableIdsArray.get(1);
-			String line = primaryId + "\t" + String.join(",", secondaryIds) + "\n";
-			Files.write(Paths.get(filename), line.getBytes(), StandardOpenOption.APPEND);
-		}
-		String outpathName = releaseNumber + "/" + filename;
-		Files.move(Paths.get(filename), Paths.get(outpathName), StandardCopyOption.REPLACE_EXISTING);
+		Files.deleteIfExists(Paths.get(filename));
+		Files.createFile(Paths.get(filename));
+
+		writeMappingsToFile(releaseNumber, stableIdsToOldIdsMappings, currentStableIdentifiers);
 
 		logger.info("MapOldStableIds finished");
 	}
 
-	// Iterate through returned results of DB IDs and stable IDs
-	private static Map<String, List<String>> getDbIdToStableIds(ResultSet resultSet) throws SQLException {
+	/**
+	 * Creates a MySQL driver that queries the stable_identifiers database for identifier and instanceId from the StableIdentifier table.
+	 * @param dba MySQLAdaptor, Not used to query the database, but to supply database parameters like host, username and password.
+	 * @return ResultSet from MySQL stable_identifiers database that consists of identifiers and their associated instanceId
+	 * @throws ClassNotFoundException - Thrown if MySQL driver class isn't found
+	 * @throws SQLException - Thrown if there are issues connecting/querying/interacting with stable_identifiers database
+	 */
+	private static ResultSet retrieveAllStableIdentifiers(MySQLAdaptor dba) throws ClassNotFoundException, SQLException {
+		// Need to use mysql driver to access stable_identifiers db
+		logger.info("Connecting to stable_identifiers db...");
+		Class.forName("com.mysql.jdbc.Driver");
+		Connection connect = DriverManager.getConnection("jdbc:mysql://" + dba.getDBHost() + "/stable_identifiers?" + "user=" + dba.getDBUser() + "&password=" + dba.getDBPwd());
+		Statement statement = connect.createStatement();
+		return statement.executeQuery("SELECT identifier,instanceId FROM StableIdentifier");
+	}
+
+	/**
+	 * Checks that the primary identifier taken from the stable_identifiers database is currently used, and it has secondary mappings.
+	 * @param currentStableIdentifiers Set<String> - Set of all StableIdentifiers currently in database.
+	 * @param primaryId String - Primary StableIdentifier that maps to secondaryIds.
+	 * @param secondaryIds List<String> - All StableIdentifiers (old and new formats) that map to the primary stable identifier.
+	 * @return Boolean, indicating it is a currently used StableIdentifier with secondary mappings.
+	 */
+	private static boolean currentStableIdentifierWithMapping(Set<String> currentStableIdentifiers, String primaryId, List<String> secondaryIds) {
+		return currentStableIdentifiers.contains(primaryId) && !secondaryIds.isEmpty();
+	}
+
+	/**
+	 * Retrieves all StableIdentifiers in the current release database.
+	 * @param dba MySQLAdaptor, connecting to release_current database.
+	 * @return Set<String>, all StableIdentifiers in current release database.
+	 * @throws Exception - Thrown by MySQLAdaptor
+	 */
+	private static Set<String> getCurrentStableIdentifiers(MySQLAdaptor dba) throws Exception {
+		Collection<GKInstance> stableIdentifierInstances = dba.fetchInstancesByClass(ReactomeJavaConstants.StableIdentifier);
+		Set<String> currentStableIdentifiersSet = new HashSet<>();
+		for (GKInstance stableIdentifierInst : stableIdentifierInstances) {
+			currentStableIdentifiersSet.add(stableIdentifierInst.getAttributeValue(ReactomeJavaConstants.identifier).toString());
+		}
+		return currentStableIdentifiersSet;
+	}
+
+	/**
+	 * Uses the resultSet from the stable_identifiers database query (which retrieved *all* StableIdentifiers and
+	 * their associated instance ids that have ever existed in Reactome) to build a map of instance IDs to StableIdentifiers.
+	 * @param stableIdResults ResultSet - Data result of query to stable_identifiers database for stable identifiers and associated instance IDs.
+	 * @return Map<String, List<String>> - Mapping of db IDs to Stable Identifiers.
+	 * @throws SQLException - Thrown if there are issues accessing the ResultSet object.
+	 */
+	private static Map<String, List<String>> getDbIdToStableIds(ResultSet stableIdResults) throws SQLException {
 		Map<String, List<String>> dbIdToStableIds = new HashMap<>();
 
 		// Iterate through returned results of DB IDs and stable IDs
-		while (resultSet.next()) {
-			String stableId = resultSet.getString(1);
-			String dbId = resultSet.getString(2);
+		while (stableIdResults.next()) {
+			String stableId = stableIdResults.getString(1);
+			String dbId = stableIdResults.getString(2);
 
-			if (dbIdToStableIds.get(dbId) != null) {
-				dbIdToStableIds.get(dbId).add(stableId);
-			} else {
-				List<String> stableIds = new ArrayList<>(Collections.singletonList(stableId));
-				dbIdToStableIds.put(dbId, stableIds);
+			dbIdToStableIds.computeIfAbsent(dbId, k -> new ArrayList<>()).add(stableId);
+		}
+		return dbIdToStableIds;
+	}
+
+	/**
+	 * With the old stable identifier mappings completed, write the results to the 'reactome_stable_ids.txt' file.
+	 * @param releaseNumber String - Current release number, used for storing files in release-specific location.
+	 * @param stableIdsToOldIdsMappings List<List<Object>> - List of current stable identifier mappings to older mappings.
+	 * The interior List<Object> is of the form [String, List<String>].
+	 * @param currentStableIdentifiers Set<String>, all StableIdentifiers in current release database.
+	 * @throws IOException - Thrown if there are issues with creating or moving mapping file.
+	 */
+	private static void writeMappingsToFile(String releaseNumber, List<List<Object>> stableIdsToOldIdsMappings, Set<String> currentStableIdentifiers) throws IOException {
+		String header = "# Reactome stable IDs for release " + releaseNumber + "\n" + "Stable_ID\told_identifier(s)\n";
+		Files.write(Paths.get(filename), header.getBytes(), StandardOpenOption.APPEND);
+		for (List<Object> stableIdsArray : stableIdsToOldIdsMappings)
+		{
+			String primaryId = (String) stableIdsArray.get(0);
+			@SuppressWarnings("unchecked")
+			List<String> secondaryIds = (ArrayList<String>) stableIdsArray.get(1);
+			if (currentStableIdentifierWithMapping(currentStableIdentifiers, primaryId, secondaryIds)) {
+				String line = primaryId + "\t" + String.join(",", secondaryIds) + "\n";
+				Files.write(Paths.get(filename), line.getBytes(), StandardOpenOption.APPEND);
 			}
 		}
-
-		return dbIdToStableIds;
+		String outpathName = releaseNumber + "/" + filename;
+		Files.move(Paths.get(filename), Paths.get(outpathName), StandardCopyOption.REPLACE_EXISTING);
 	}
 }


### PR DESCRIPTION
This PR adjusts the 'MapOldStableIds' code in download directory to only map _current_ StableIdentifiers to their older IDs. 

I also refactored the code where possible. There are some odd data structures in the code (List<List<Object>>). This is because the Object within that structure can be either a String or a List. This was the result of me copying the Perl code back in the day. While it can definitely be done better, I figured that since we are in the midst of merging the StIdHistory and Curator databases, maybe we can wait until after that is done to revisit this code for a re-do.