### PR TITLE
Feature/only run protege

### DIFF
--- a/src/main/java/org/reactome/release/downloaddirectory/ProtegeExporter.java
+++ b/src/main/java/org/reactome/release/downloaddirectory/ProtegeExporter.java
@@ -78,7 +78,7 @@ public class ProtegeExporter
 			List<String> extraIncs = Arrays.asList(extraIncludeStr.split(","));
 			this.setExtraIncludes(extraIncs);
 		}
-		String pathToWrapper = props.getProperty(propsPrefix+".pathToWrapperScript");
+		String pathToWrapper = props.getProperty(propsPrefix+".pathToWrapperScript", "src/main/resources");
 		this.setPathToWrapperScript(pathToWrapper);
 		this.setDownloadDirectory(downloadDir);
 

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -11,8 +11,7 @@ absoluteReleaseDirectoryPath=/usr/local/gkb/scripts/release/
 speciesConfigPath=src/main/resources/Species.json
 stepsToRunConfigPath=src/main/resources/stepsToRun.config
 # Config for protege exporter
-#protegeexporter.pathToWrapperScript=/usr/local/reactomes/Reactome/production/Release/scripts/release/download_directory/data-release-pipeline/downloadDirectory/src/main/resources/
-protegeexporter.pathToWrapperScript=/var/lib/jenkins/workspace/Releases/74/DownloadDirectory/src/main/resources/
+protegeexporter.pathToWrapperScript=src/main/resources
 # 5 is for an 8-core system (need to leave some resources for MySQL and the OS).
 # If you have a different number of cores, you can change this value, but try to
 # leave at least 2 or 3 cors available for other processes (such as MySQL and OS).

--- a/src/main/resources/stepsToRun.config
+++ b/src/main/resources/stepsToRun.config
@@ -1,14 +1,14 @@
 # This file is used to specify which steps in DownloadDirectory to execute.
 # Comment out any steps that don't need to be run.
 
-DatabaseDumps
-BioPAX2
-BioPAX3
-GSEAOutput
-FetchTestReactomeOntologyFiles
-PathwaySummationMappingFile
-MapOldStableIds
-GenerateGOAnnotationFile
-HumanPathwaysWithDiagrams
-CreateReactome2BioSystems
+#DatabaseDumps
+#BioPAX2
+#BioPAX3
+#GSEAOutput
+#FetchTestReactomeOntologyFiles
+#PathwaySummationMappingFile
+#MapOldStableIds
+#GenerateGOAnnotationFile
+#HumanPathwaysWithDiagrams
+#CreateReactome2BioSystems
 protegeexporter

--- a/src/main/resources/stepsToRun.config
+++ b/src/main/resources/stepsToRun.config
@@ -1,14 +1,14 @@
 # This file is used to specify which steps in DownloadDirectory to execute.
 # Comment out any steps that don't need to be run.
 
-#DatabaseDumps
-#BioPAX2
-#BioPAX3
-#GSEAOutput
-#FetchTestReactomeOntologyFiles
-#PathwaySummationMappingFile
-#MapOldStableIds
-#GenerateGOAnnotationFile
-#HumanPathwaysWithDiagrams
-#CreateReactome2BioSystems
+DatabaseDumps
+BioPAX2
+BioPAX3
+GSEAOutput
+FetchTestReactomeOntologyFiles
+PathwaySummationMappingFile
+MapOldStableIds
+GenerateGOAnnotationFile
+HumanPathwaysWithDiagrams
+CreateReactome2BioSystems
 protegeexporter


### PR DESCRIPTION
This 'pathToWrapperScript' value has always caused problems for download directory when run by Jenkins. I realize now it makes a lot more sense to just give the path value a default, so that future release runners don't need to sweat over it!