### PR TITLE
better-archive-creation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,10 +54,6 @@ pipeline {
 		        	script{
 					def releaseVersion = utils.getReleaseVersion()
 					def downloadDirectoryArchive = "download-directory-v${releaseVersion}.tgz"
-//					dir("${releaseVersion}"){
-//						sh "tar -zcvf ${downloadDirectoryArchive} *"
-//					}
-//					sh "mv ${releaseVersion}/${downloadDirectoryArchive} ."
 					sh "tar -zcvf ${downloadDirectoryArchive} ${releaseVersion}"
 					sh "mv ${releaseVersion}/* ${env.ABS_DOWNLOAD_PATH}/${releaseVersion}/"
 					sh "rm -r ${releaseVersion}*"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,8 +57,8 @@ pipeline {
 //					dir("${releaseVersion}"){
 //						sh "tar -zcvf ${downloadDirectoryArchive} *"
 //					}
+//					sh "mv ${releaseVersion}/${downloadDirectoryArchive} ."
 					sh "tar -zcvf ${downloadDirectoryArchive} ${releaseVersion}"
-					sh "mv ${releaseVersion}/${downloadDirectoryArchive} ."
 					sh "mv ${releaseVersion}/* ${env.ABS_DOWNLOAD_PATH}/${releaseVersion}/"
 					sh "rm -r ${releaseVersion}*"
 		        	}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,9 +54,10 @@ pipeline {
 		        	script{
 					def releaseVersion = utils.getReleaseVersion()
 					def downloadDirectoryArchive = "download-directory-v${releaseVersion}.tgz"
-					dir("${releaseVersion}"){
-						sh "tar -zcvf ${downloadDirectoryArchive} *"
-					}
+//					dir("${releaseVersion}"){
+//						sh "tar -zcvf ${downloadDirectoryArchive} *"
+//					}
+					sh "tar -zcvf ${downloadDirectoryArchive} ${releaseVersion}"
 					sh "mv ${releaseVersion}/${downloadDirectoryArchive} ."
 					sh "mv ${releaseVersion}/* ${env.ABS_DOWNLOAD_PATH}/${releaseVersion}/"
 					sh "rm -r ${releaseVersion}*"


### PR DESCRIPTION
Create an archive that contains the _directory_ containing the files, not an archive that contains the files with no surrounding container. 
Doing it this way ensures that when you run `tar -xzf ${downloadDirectoryArchive}.tgz` you will get a _directory_, and _that_ will contain the files. 
Otherwise, you will end up filling your current working directory with the contents of the archive.

This should fix #17 